### PR TITLE
Add side dish and grill attributes to burger items

### DIFF
--- a/app/public/data/menu_items_refactored.json
+++ b/app/public/data/menu_items_refactored.json
@@ -6205,9 +6205,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and bagged salad, frozen sweet potato fries"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "bagged salad, frozen sweet potato fries"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -7708,9 +7714,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and roasted potatoes/turnips"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "roasted potatoes/turnips"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -7869,9 +7881,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and apple spinach salad"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "apple spinach salad"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -10099,9 +10117,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and turnips"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "turnips"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -15881,9 +15905,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet potato fries"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet potato fries"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -17914,9 +17944,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and asparagus"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "asparagus"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -18547,9 +18583,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and grilled asparagus, chips"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "grilled asparagus, chips"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -19201,9 +19243,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet potato fries"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet potato fries"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -21021,9 +21069,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet potato fries"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet potato fries"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -21949,9 +22003,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and corn and zucchini/squash"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "corn and zucchini/squash"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -23854,9 +23914,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet corn and bagged salad"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet corn and bagged salad"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -24723,9 +24789,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet corn"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet corn"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -25636,9 +25708,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and \ud83c\udf3d"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "\ud83c\udf3d"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -25705,9 +25783,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and pattypan squash"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "pattypan squash"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -25843,9 +25927,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and frozen (regular) fries"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "frozen (regular) fries"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -29398,9 +29488,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet corn"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet corn"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,

--- a/data/menu_items_refactored.json
+++ b/data/menu_items_refactored.json
@@ -6205,9 +6205,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and bagged salad, frozen sweet potato fries"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "bagged salad, frozen sweet potato fries"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -7708,9 +7714,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and roasted potatoes/turnips"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "roasted potatoes/turnips"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -7869,9 +7881,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and apple spinach salad"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "apple spinach salad"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -10099,9 +10117,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and turnips"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "turnips"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -15881,9 +15905,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet potato fries"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet potato fries"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -17914,9 +17944,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and asparagus"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "asparagus"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -18547,9 +18583,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and grilled asparagus, chips"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "grilled asparagus, chips"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -19201,9 +19243,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet potato fries"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet potato fries"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -21021,9 +21069,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet potato fries"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet potato fries"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -21949,9 +22003,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and corn and zucchini/squash"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "corn and zucchini/squash"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -23854,9 +23914,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet corn and bagged salad"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet corn and bagged salad"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -24723,9 +24789,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet corn"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet corn"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -25636,9 +25708,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and \ud83c\udf3d"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "\ud83c\udf3d"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -25705,9 +25783,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and pattypan squash"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "pattypan squash"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -25843,9 +25927,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and frozen (regular) fries"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "frozen (regular) fries"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,
@@ -29398,9 +29488,15 @@
       "sections": [],
       "source_hints": [],
       "item_texts": [
-        "Burgers and sweet corn"
+        "Burgers"
       ],
-      "count": 1
+      "count": 1,
+      "side_dish": [
+        "sweet corn"
+      ],
+      "attributes": [
+        "grill"
+      ]
     },
     {
       "url": null,


### PR DESCRIPTION
### Motivation
- Normalize menu item data where many entries begin with "Burgers and ..." by separating the side information from the main dish and marking burgers as grilled. 
- Keep the refactored dataset and the app public copy in sync so downstream consumers can rely on the new fields.

### Description
- Updated `data/menu_items_refactored.json` and `app/public/data/menu_items_refactored.json` to replace item texts that start with `"Burgers and "` with `"Burgers"` and extracted the remainder into a new `side_dish` field as an array. 
- Added or merged a `grill` entry into the `attributes` field for those burger entries, preserving existing `attributes` types by converting strings to arrays when necessary. 
- When a `side_dish` already existed the script merged new side values into the existing list to avoid data loss. 
- Changes are limited to the two data files (no code or API changes). 

### Testing
- No automated tests were run; this is a data-only transformation that updated the two refactored JSON files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69817499aed083308f5eba3630aacbd8)