### PR TITLE
Add brats recipe auto-linking

### DIFF
--- a/app/public/data/menus.json
+++ b/app/public/data/menus.json
@@ -2602,7 +2602,13 @@
           "meal_type": "dinner",
           "season": "fall",
           "source_hint": null,
-          "links": [],
+          "links": [
+            {
+              "text": "Beer Braised Brats with Apple Mustard Slaw",
+              "url": "https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/",
+              "auto_added": true
+            }
+          ],
           "urls": []
         },
         {
@@ -12592,7 +12598,13 @@
           "meal_type": "dinner",
           "season": "spring",
           "source_hint": "grill",
-          "links": [],
+          "links": [
+            {
+              "text": "Beer Braised Brats with Apple Mustard Slaw",
+              "url": "https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/",
+              "auto_added": true
+            }
+          ],
           "urls": []
         },
         {
@@ -12717,7 +12729,13 @@
           "meal_type": "dinner",
           "season": "spring",
           "source_hint": null,
-          "links": [],
+          "links": [
+            {
+              "text": "Beer Braised Brats with Apple Mustard Slaw",
+              "url": "https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/",
+              "auto_added": true
+            }
+          ],
           "urls": []
         },
         {

--- a/data/menus.json
+++ b/data/menus.json
@@ -2602,7 +2602,13 @@
           "meal_type": "dinner",
           "season": "fall",
           "source_hint": null,
-          "links": [],
+          "links": [
+            {
+              "text": "Beer Braised Brats with Apple Mustard Slaw",
+              "url": "https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/",
+              "auto_added": true
+            }
+          ],
           "urls": []
         },
         {
@@ -12592,7 +12598,13 @@
           "meal_type": "dinner",
           "season": "spring",
           "source_hint": "grill",
-          "links": [],
+          "links": [
+            {
+              "text": "Beer Braised Brats with Apple Mustard Slaw",
+              "url": "https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/",
+              "auto_added": true
+            }
+          ],
           "urls": []
         },
         {
@@ -12717,7 +12729,13 @@
           "meal_type": "dinner",
           "season": "spring",
           "source_hint": null,
-          "links": [],
+          "links": [
+            {
+              "text": "Beer Braised Brats with Apple Mustard Slaw",
+              "url": "https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/",
+              "auto_added": true
+            }
+          ],
           "urls": []
         },
         {

--- a/scripts/auto_add_links.py
+++ b/scripts/auto_add_links.py
@@ -26,6 +26,22 @@ MAPPING = {
         "url": "https://pinchofyum.com/yummy-salmon-burgers-slaw",
         "title": "Yummy Salmon Burgers with Slaw",
     },
+    "beer braised brats with apple mustard slaw": {
+        "url": "https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/",
+        "title": "Beer Braised Brats with Apple Mustard Slaw",
+    },
+    "beer braised brats and apple mustard slaw": {
+        "url": "https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/",
+        "title": "Beer Braised Brats with Apple Mustard Slaw",
+    },
+    "beer braised brats": {
+        "url": "https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/",
+        "title": "Beer Braised Brats with Apple Mustard Slaw",
+    },
+    "beer brats with apple mustard slaw": {
+        "url": "https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/",
+        "title": "Beer Braised Brats with Apple Mustard Slaw",
+    },
     "chickpea couscous bowls with tahini sauce": {
         "url": "https://www.acouplecooks.com/chickpea-couscous-bowls-tahini-sauce/",
         "title": "Chickpea Couscous Bowls with Tahini Sauce",


### PR DESCRIPTION
### Motivation
- Ensure menu items mentioning brats are automatically enriched with the same recipe links that burgers receive so users can click through to the source recipe.

### Description
- Added mapping entries to `scripts/auto_add_links.py` for several brats variants (e.g., `"beer braised brats with apple mustard slaw"`, `"beer braised brats"`, `"beer brats with apple mustard slaw"`).
- The mappings point to `https://honestlyyum.com/6637/beer-braised-brats-with-apple-mustard-slaw/` with the title `Beer Braised Brats with Apple Mustard Slaw`.
- Ran the link enrichment to update menu datasets, which updated `data/menus.json` and `app/public/data/menus.json` to include the newly auto-added brats links.

### Testing
- Ran `python scripts/auto_add_links.py`, which completed and printed `Auto-added links: 3`.
- Verified the three menu items now contain an `auto_added` link entry in both `data/menus.json` and `app/public/data/menus.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698174fd18dc8330a54a3ad2a2accf9f)